### PR TITLE
Look for `setImmediate` in all possible locations.

### DIFF
--- a/main.js
+++ b/main.js
@@ -49,5 +49,8 @@ exports._unrefActive = exports.active = function(item) {
 
 // setimmediate attaches itself to the global object
 require("setimmediate");
-exports.setImmediate = self && self.setImmediate || global && global.setImmediate || window && window.setImmediate || setInterval;
-exports.clearImmediate = self && self.clearImmediate || global && global.clearImmediate || window && window.clearImmediate || clearInterval;
+// on some exotic platforms the window object is not the same as the self, global or this objects.
+// look for setImmediate/clearImmediate in the "global" objects in the same order as the "setimmediate"
+// library tries to attach itself. If the functions cannot be found, fallback to setInterval/clearInterval.
+exports.setImmediate = self && self.setImmediate || global && global.setImmediate || this && this.setImmediate || setInterval;
+exports.clearImmediate = self && self.clearImmediate || global && global.clearImmediate || this && this.clearImmediate || clearInterval;

--- a/main.js
+++ b/main.js
@@ -49,5 +49,5 @@ exports._unrefActive = exports.active = function(item) {
 
 // setimmediate attaches itself to the global object
 require("setimmediate");
-exports.setImmediate = setImmediate;
-exports.clearImmediate = clearImmediate;
+exports.setImmediate = self && self.setImmediate || global && global.setImmediate || window && window.setImmediate || setInterval;
+exports.clearImmediate = self && self.clearImmediate || global && global.clearImmediate || window && window.clearImmediate || clearInterval;


### PR DESCRIPTION
Fixes #25
Looks for setImmediate in all objects in the same order as the `setimmediate` library adds them, if not found, it falls back to using `setTimeout` and `clearTimeout` which behave very similarly to `setImmediate` when no parameters passed.