### PR TITLE
Use global `this` instead of `window`

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-var scope = (typeof self !== "undefined" && self) || window;
+var scope = this;
 var apply = Function.prototype.apply;
 
 // DOM APIs, for completeness


### PR DESCRIPTION
This makes it possible to run the top-level code in timers-browserify in JavaScript engine shells (that lack a `window` object) directly again.

Fixes https://github.com/v8/web-tooling-benchmark/issues/50.