### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 node_modules
 example
+.DS_Store


### PR DESCRIPTION
The current version of the module includes .DS_Store entries https://unpkg.com/browse/timers-browserify@2.0.11/

`.DS_Store` is a macOS artifact.  npm does not automatically ignore entries in `.gitignore` if a `.npmignore` file is present.  This PR adds the missing line to ensure that `.DS_Store` is not included in future versions.